### PR TITLE
Fix grid visibility on terminals without truecolor support

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -17,6 +17,9 @@
 #define BOX_COLOR_CYAN 6
 #define BOX_COLOR_WHITE 7
 
+/* Grid color pair index */
+#define GRID_COLOR_PAIR 8
+
 /* Initial capacity for dynamic connection array */
 #define INITIAL_CONNECTION_CAPACITY 8
 

--- a/src/render.c
+++ b/src/render.c
@@ -738,8 +738,8 @@ void render_grid(const Canvas *canvas, const Viewport *vp) {
     if (grid_start_x < world_left) grid_start_x += spacing;
     if (grid_start_y < world_top) grid_start_y += spacing;
 
-    /* Use dim color for grid (gray) */
-    attron(COLOR_PAIR(8));  /* Dim gray - COLOR_PAIR(8) */
+    /* Use dim white for grid - visible on all terminal types */
+    attron(COLOR_PAIR(8) | A_DIM);  /* Dim white = gray on all terminals */
 
     /* Draw grid points (dot grid) */
     for (double world_x = grid_start_x; world_x <= world_right; world_x += spacing) {
@@ -764,7 +764,7 @@ void render_grid(const Canvas *canvas, const Viewport *vp) {
         }
     }
 
-    attroff(COLOR_PAIR(8));
+    attroff(COLOR_PAIR(8) | A_DIM);
 }
 
 /* Render focused box in full-screen mode (Phase 5b) */

--- a/src/render.c
+++ b/src/render.c
@@ -739,7 +739,7 @@ void render_grid(const Canvas *canvas, const Viewport *vp) {
     if (grid_start_y < world_top) grid_start_y += spacing;
 
     /* Use dim white for grid - visible on all terminal types */
-    attron(COLOR_PAIR(8) | A_DIM);  /* Dim white = gray on all terminals */
+    attron(COLOR_PAIR(GRID_COLOR_PAIR) | A_DIM);  /* Dim white = gray on all terminals */
 
     /* Draw grid points (dot grid) */
     for (double world_x = grid_start_x; world_x <= world_right; world_x += spacing) {
@@ -764,7 +764,7 @@ void render_grid(const Canvas *canvas, const Viewport *vp) {
         }
     }
 
-    attroff(COLOR_PAIR(8) | A_DIM);
+    attroff(COLOR_PAIR(GRID_COLOR_PAIR) | A_DIM);
 }
 
 /* Render focused box in full-screen mode (Phase 5b) */

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -83,7 +83,7 @@ int terminal_init(void) {
         init_pair(BOX_COLOR_WHITE, COLOR_WHITE, -1);
 
         /* Grid color (Phase 4) - dim white for visibility on all terminals */
-        init_pair(8, COLOR_WHITE, -1);  /* Use white with A_DIM for universal gray */
+        init_pair(GRID_COLOR_PAIR, COLOR_WHITE, -1);  /* Use white with A_DIM for universal gray */
     }
 
     return 0;

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -82,8 +82,8 @@ int terminal_init(void) {
         init_pair(BOX_COLOR_CYAN, COLOR_CYAN, -1);
         init_pair(BOX_COLOR_WHITE, COLOR_WHITE, -1);
 
-        /* Grid color (Phase 4) - dim gray */
-        init_pair(8, COLOR_BLACK, -1);  /* Use bright black (gray) */
+        /* Grid color (Phase 4) - dim white for visibility on all terminals */
+        init_pair(8, COLOR_WHITE, -1);  /* Use white with A_DIM for universal gray */
     }
 
     return 0;


### PR DESCRIPTION
## Summary

Grid dots were invisible on terminals that don't set `COLORTERM=truecolor`, such as Windows Terminal for WSL with default settings.

Fixes #30

## Changes

- `src/terminal.c`: Changed grid color from `COLOR_BLACK` to `COLOR_WHITE`
- `src/render.c`: Added `A_DIM` attribute to grid rendering

The combination of `COLOR_WHITE` + `A_DIM` renders as gray on all terminal types, regardless of truecolor support.

## Root Cause

| Terminal | COLORTERM | Grid Visible (before) |
|----------|-----------|----------------------|
| GitHub Codespaces | `truecolor` | Yes |
| Windows Terminal (WSL) | (empty) | No |

`COLOR_BLACK` on transparent background (`-1`) is invisible on dark backgrounds unless the terminal interprets it as "bright black" (gray), which requires truecolor support.

## Testing

- [x] All tests pass (`make test`) - 442 assertions
- [x] Compiles with zero warnings (`-Wall -Wextra -Werror`)

## Type

- [x] Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)