### PR TITLE
feat: start with empty canvas by default (Issue #47)

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -15,6 +15,7 @@ typedef struct {
     /* General settings */
     bool show_visualizer;
     bool auto_save;
+    bool show_welcome_box;      /* Show welcome box on empty canvas start (Issue #47) */
 
     /* Box template settings (Issue #17) */
     int template_square_width;

--- a/src/config.c
+++ b/src/config.c
@@ -16,6 +16,7 @@ void config_init_defaults(AppConfig *config) {
     /* General */
     config->show_visualizer = true;
     config->auto_save = false;
+    config->show_welcome_box = false;   /* Empty canvas by default (Issue #47) */
 
     /* Box templates (Issue #17) */
     config->template_square_width = 20;
@@ -147,6 +148,8 @@ static int parse_config_line(AppConfig *config, const char *section, const char 
             config->show_visualizer = (strcmp(value, "true") == 0);
         } else if (strcmp(key, "auto_save") == 0) {
             config->auto_save = (strcmp(value, "true") == 0);
+        } else if (strcmp(key, "show_welcome_box") == 0) {
+            config->show_welcome_box = (strcmp(value, "true") == 0);
         }
     } else if (strcmp(section, "grid") == 0) {
         if (strcmp(key, "visible") == 0) {

--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,7 @@ static void print_usage(const char *program_name) {
     printf("  -h, --help     Show this help message and exit\n");
     printf("\nFILE:\n");
     printf("  Optional canvas file to load on startup (*.txt)\n");
-    printf("  If not specified, starts with sample canvas\n");
+    printf("  If not specified, starts with empty canvas\n");
     printf("\nCONFIGURATION:\n");
     printf("  Config file: ~/.config/boxes-live/config.ini\n");
     printf("  See config.ini.example for all available settings\n");
@@ -49,8 +49,14 @@ static void print_usage(const char *program_name) {
     printf("  %s demos/live_monitor.txt   # Load demo file\n", program_name);
 }
 
-/* Initialize canvas with simple welcome box */
-static void init_sample_canvas(Canvas *canvas) {
+/* Initialize empty canvas (Issue #47 - default behavior) */
+static void init_empty_canvas(Canvas *canvas) {
+    canvas_init(canvas, 200.0, 100.0);
+    /* Canvas starts empty - status bar will show onboarding hint */
+}
+
+/* Initialize canvas with welcome box (legacy behavior, opt-in via config) */
+static void init_welcome_canvas(Canvas *canvas) {
     canvas_init(canvas, 200.0, 100.0);
 
     /* Create single welcome box */
@@ -176,8 +182,12 @@ int main(int argc, char *argv[]) {
             viewport.cam_y = center_y - (viewport.term_height / 2.0) / viewport.zoom;
         }
     } else {
-        /* Initialize with sample boxes */
-        init_sample_canvas(&canvas);
+        /* Initialize canvas based on config (Issue #47) */
+        if (app_config.show_welcome_box) {
+            init_welcome_canvas(&canvas);
+        } else {
+            init_empty_canvas(&canvas);
+        }
     }
 
     /* Apply config to grid defaults (Phase 5a) */


### PR DESCRIPTION
## Summary
Change default behavior to start with an empty canvas instead of the welcome box, providing a cleaner first-time experience for new users.

Fixes #47

## Changes
- Add `show_welcome_box` config option (default: `false`)
- Create `init_empty_canvas()` for new default behavior
- Rename `init_sample_canvas()` to `init_welcome_canvas()`
- Update help text to reflect new default

## Configuration
Users can restore the welcome box by adding to `~/.config/boxes-live/config.ini`:
```ini
[general]
show_welcome_box = true
```

## Testing
- [x] All tests pass (`make test`)
- [x] Build succeeds with zero warnings (`make clean && make`)
- [x] Manual testing: app starts with empty canvas

## Type
- [x] New feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)