### PR TITLE
fix: initialize joystick axes to center on startup

### DIFF
--- a/src/joystick.c
+++ b/src/joystick.c
@@ -124,6 +124,12 @@ int joystick_init(JoystickState *state) {
         debug_log_event("Y-axis: using default 16-bit range (ioctl failed)\n");
     }
 
+    // Initialize axis values to center (fixes diagonal-on-startup bug)
+    state->axis_x = state->axis_x_center;
+    state->axis_y = state->axis_y_center;
+    debug_log_event("Axes initialized to center: x=%d, y=%d\n",
+                   state->axis_x, state->axis_y);
+
     state->available = true;
     return 0;
 }
@@ -588,8 +594,10 @@ bool joystick_try_reconnect(JoystickState *state) {
     // Reset state
     memset(state->button, 0, sizeof(state->button));
     memset(state->button_prev, 0, sizeof(state->button_prev));
-    state->axis_x = 0;
-    state->axis_y = 0;
+
+    // Initialize axis values to center (fixes diagonal-on-startup bug)
+    state->axis_x = state->axis_x_center;
+    state->axis_y = state->axis_y_center;
 
     return true;
 }


### PR DESCRIPTION
## Summary

**Critical bug fix** - Joystick appeared "pushed diagonal" on startup, causing immediate unexpected viewport movement when boxes-live launches.

## Root Cause

`axis_x` and `axis_y` were initialized to 0, but the joystick center value might not be 0 (e.g., 128 for a 0-255 range device). This made the normalized axis calculation think the stick was pushed when it was actually neutral.

## Changes

- Initialize `axis_x` to `axis_x_center` after querying device info
- Initialize `axis_y` to `axis_y_center` after querying device info  
- Applied fix to both `joystick_init()` and `joystick_try_reconnect()`

## Testing

- [x] Builds without warnings (`make clean && make`)
- [x] Joystick starts in neutral position
- [x] No unexpected viewport movement on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)