### PR TITLE
Add BoxContentType enum and content source fields

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -26,7 +26,7 @@
 /* Default connection color */
 #define CONNECTION_COLOR_DEFAULT BOX_COLOR_CYAN
 
-/* Box type enumeration (Issue #33) */
+/* Box type enumeration for visual styling (Issue #33) */
 typedef enum {
     BOX_TYPE_NOTE = 0,      /* Default note box */
     BOX_TYPE_TASK,          /* Task/todo box */
@@ -34,6 +34,13 @@ typedef enum {
     BOX_TYPE_STICKY,        /* Sticky note box */
     BOX_TYPE_COUNT          /* Total number of box types */
 } BoxType;
+
+/* Box content type enumeration for content source (Issue #54) */
+typedef enum {
+    BOX_CONTENT_TEXT = 0,   /* Static text content (default, current behavior) */
+    BOX_CONTENT_FILE,       /* Content loaded from file */
+    BOX_CONTENT_COMMAND     /* Content from command output */
+} BoxContentType;
 
 /* Display mode for boxes (Issue #33) */
 typedef enum {
@@ -62,7 +69,12 @@ typedef struct {
     bool selected;      /* Is this box currently selected? */
     int id;             /* Unique box identifier */
     int color;          /* Color pair index (0 = default) */
-    BoxType box_type;   /* Box type (note, task, code, sticky) - Issue #33 */
+    BoxType box_type;   /* Box visual type (note, task, code, sticky) - Issue #33 */
+
+    /* Content source fields (Issue #54) */
+    BoxContentType content_type;  /* Content source type (text, file, command) */
+    char *file_path;              /* File path for BOX_CONTENT_FILE (NULL otherwise) */
+    char *command;                /* Command string for BOX_CONTENT_COMMAND (NULL otherwise) */
 } Box;
 
 /* Viewport structure for camera/view control */

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -77,6 +77,13 @@ void canvas_cleanup(Canvas *canvas) {
             }
             free(box->content);
         }
+        /* Free content source fields (Issue #54) */
+        if (box->file_path) {
+            free(box->file_path);
+        }
+        if (box->command) {
+            free(box->command);
+        }
     }
 
     if (canvas->boxes) {
@@ -146,6 +153,11 @@ int canvas_add_box(Canvas *canvas, double x, double y, int width, int height, co
     box->color = BOX_COLOR_DEFAULT;
     box->box_type = BOX_TYPE_NOTE;  /* Default to NOTE type (Issue #33) */
 
+    /* Initialize content source fields (Issue #54) */
+    box->content_type = BOX_CONTENT_TEXT;  /* Default to static text */
+    box->file_path = NULL;
+    box->command = NULL;
+
     canvas->box_count++;
 
     return box->id;
@@ -199,6 +211,13 @@ int canvas_remove_box(Canvas *canvas, int box_id) {
                     free(box->content[j]);
                 }
                 free(box->content);
+            }
+            /* Free content source fields (Issue #54) */
+            if (box->file_path) {
+                free(box->file_path);
+            }
+            if (box->command) {
+                free(box->command);
             }
 
             /* Shift remaining boxes down */


### PR DESCRIPTION
## Summary
Add infrastructure for different box content sources (text, file, command) as Phase 1 of the file/process association feature.

Fixes #54

## Changes

| File | Description |
|------|-------------|
| `include/types.h` | Add `BoxContentType` enum and extend `Box` struct |
| `src/canvas.c` | Initialize and free new fields |
| `src/persistence.c` | Save/load with backward compatibility |
| `tests/test_persistence.c` | Add roundtrip test for content types |

### New Fields in Box Structure
```c
BoxContentType content_type;  // TEXT, FILE, or COMMAND
char *file_path;              // For FILE type (NULL otherwise)
char *command;                // For COMMAND type (NULL otherwise)
```

### Backward Compatibility
The persistence layer handles three file formats:
- **7 fields**: Pre-#33 format → defaults to NOTE/TEXT
- **8 fields**: #33 format → defaults to TEXT  
- **9 fields**: New format with content type, file_path, command

Existing canvas files load without errors.

## Testing
- [x] All tests pass (`make test` - 86 passed in persistence alone)
- [x] Build succeeds with zero warnings
- [x] New content type test verifies roundtrip for all three types

## Type
- [x] Enhancement (Phase 1 of #19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)