### PR TITLE
Add command execution with :run command (Issue #56)

### DIFF
--- a/include/command_runner.h
+++ b/include/command_runner.h
@@ -1,0 +1,61 @@
+#ifndef COMMAND_RUNNER_H
+#define COMMAND_RUNNER_H
+
+#include "types.h"
+
+/* Maximum command output size (in bytes) */
+#define MAX_COMMAND_OUTPUT (64 * 1024)  /* 64 KB */
+
+/* Maximum output lines to store */
+#define MAX_COMMAND_LINES 1000
+
+/* Exit code field - stored in box content as metadata */
+#define EXIT_CODE_UNKNOWN -999
+
+/**
+ * Execute a command and capture its output into a box.
+ * Sets box->content_type to BOX_CONTENT_COMMAND and populates box->content.
+ * Captures both stdout and stderr (combined).
+ *
+ * @param box The box to store command output (must have box->command set)
+ * @return Exit code of the command, or -1 on execution error
+ */
+int command_runner_execute(Box *box);
+
+/**
+ * Set the command for a box (copies the string).
+ * Does not execute - call command_runner_execute() after.
+ *
+ * @param box The box to set command on
+ * @param command The command string to copy
+ * @return 0 on success, -1 on error
+ */
+int command_runner_set_command(Box *box, const char *command);
+
+/**
+ * Get the last exit code for a command box.
+ * Exit code is stored as metadata in the first line of content.
+ *
+ * @param box The command box to check
+ * @return Exit code, or EXIT_CODE_UNKNOWN if not available
+ */
+int command_runner_get_exit_code(const Box *box);
+
+/**
+ * Clear command output from a box.
+ * Clears box->content but preserves box->command for re-run.
+ *
+ * @param box The box to clear
+ */
+void command_runner_clear(Box *box);
+
+/**
+ * Check if a command string looks safe (basic validation).
+ * This is NOT a security guarantee - just catches obvious issues.
+ *
+ * @param command The command string to validate
+ * @return 1 if appears safe, 0 if suspicious
+ */
+int command_runner_validate(const char *command);
+
+#endif /* COMMAND_RUNNER_H */

--- a/src/command_runner.c
+++ b/src/command_runner.c
@@ -1,0 +1,207 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "command_runner.h"
+
+/* Internal: Store exit code as metadata line */
+static void store_exit_code(Box *box, int exit_code) {
+    if (!box || !box->content) return;
+
+    /* Add exit code as last line */
+    char exit_line[64];
+    snprintf(exit_line, sizeof(exit_line), "[Exit: %d]", exit_code);
+
+    /* Reallocate content array for one more line */
+    char **new_content = realloc(box->content, sizeof(char *) * (box->content_lines + 1));
+    if (new_content) {
+        box->content = new_content;
+        box->content[box->content_lines] = strdup(exit_line);
+        if (box->content[box->content_lines]) {
+            box->content_lines++;
+        }
+    }
+}
+
+/* Execute command and capture output */
+int command_runner_execute(Box *box) {
+    if (!box || !box->command || box->command[0] == '\0') {
+        return -1;
+    }
+
+    /* Clear any existing output */
+    command_runner_clear(box);
+
+    /* Build command with stderr redirect */
+    char cmd_with_redirect[1024];
+    snprintf(cmd_with_redirect, sizeof(cmd_with_redirect), "%s 2>&1", box->command);
+
+    /* Execute command */
+    FILE *pipe = popen(cmd_with_redirect, "r");
+    if (!pipe) {
+        return -1;
+    }
+
+    /* Read output lines */
+    char **lines = NULL;
+    int line_count = 0;
+    int capacity = 64;
+
+    lines = malloc(sizeof(char *) * capacity);
+    if (!lines) {
+        pclose(pipe);
+        return -1;
+    }
+
+    char buffer[MAX_COMMAND_OUTPUT];
+    size_t total_bytes = 0;
+
+    while (fgets(buffer, sizeof(buffer), pipe) != NULL && line_count < MAX_COMMAND_LINES) {
+        size_t len = strlen(buffer);
+        total_bytes += len;
+
+        if (total_bytes > MAX_COMMAND_OUTPUT) {
+            break;  /* Output limit reached */
+        }
+
+        /* Remove trailing newline */
+        if (len > 0 && buffer[len - 1] == '\n') {
+            buffer[len - 1] = '\0';
+            /* Also handle Windows CRLF */
+            if (len > 1 && buffer[len - 2] == '\r') {
+                buffer[len - 2] = '\0';
+            }
+        }
+
+        /* Grow array if needed */
+        if (line_count >= capacity) {
+            capacity *= 2;
+            char **new_lines = realloc(lines, sizeof(char *) * capacity);
+            if (!new_lines) {
+                break;
+            }
+            lines = new_lines;
+        }
+
+        lines[line_count] = strdup(buffer);
+        if (!lines[line_count]) {
+            break;
+        }
+        line_count++;
+    }
+
+    /* Get exit status */
+    int status = pclose(pipe);
+    int exit_code = 0;
+
+#ifdef _WIN32
+    exit_code = status;
+#else
+    if (WIFEXITED(status)) {
+        exit_code = WEXITSTATUS(status);
+    } else {
+        exit_code = -1;
+    }
+#endif
+
+    /* If no output, add a placeholder */
+    if (line_count == 0) {
+        lines[0] = strdup("(no output)");
+        if (lines[0]) {
+            line_count = 1;
+        }
+    }
+
+    /* Assign to box */
+    box->content = lines;
+    box->content_lines = line_count;
+    box->content_type = BOX_CONTENT_COMMAND;
+
+    /* Store exit code as metadata */
+    store_exit_code(box, exit_code);
+
+    return exit_code;
+}
+
+/* Set command for a box */
+int command_runner_set_command(Box *box, const char *command) {
+    if (!box || !command) {
+        return -1;
+    }
+
+    /* Free existing command */
+    if (box->command) {
+        free(box->command);
+    }
+
+    box->command = strdup(command);
+    if (!box->command) {
+        return -1;
+    }
+
+    box->content_type = BOX_CONTENT_COMMAND;
+    return 0;
+}
+
+/* Get exit code from command box */
+int command_runner_get_exit_code(const Box *box) {
+    if (!box || box->content_type != BOX_CONTENT_COMMAND) {
+        return EXIT_CODE_UNKNOWN;
+    }
+
+    if (!box->content || box->content_lines == 0) {
+        return EXIT_CODE_UNKNOWN;
+    }
+
+    /* Exit code is in the last line */
+    const char *last_line = box->content[box->content_lines - 1];
+    if (!last_line) {
+        return EXIT_CODE_UNKNOWN;
+    }
+
+    /* Parse "[Exit: N]" format */
+    int exit_code;
+    if (sscanf(last_line, "[Exit: %d]", &exit_code) == 1) {
+        return exit_code;
+    }
+
+    return EXIT_CODE_UNKNOWN;
+}
+
+/* Clear command output */
+void command_runner_clear(Box *box) {
+    if (!box) {
+        return;
+    }
+
+    if (box->content) {
+        for (int i = 0; i < box->content_lines; i++) {
+            if (box->content[i]) {
+                free(box->content[i]);
+            }
+        }
+        free(box->content);
+        box->content = NULL;
+    }
+    box->content_lines = 0;
+}
+
+/* Basic command validation */
+int command_runner_validate(const char *command) {
+    if (!command || command[0] == '\0') {
+        return 0;
+    }
+
+    /* Reject commands with dangerous shell metacharacters for injection */
+    /* Note: This is basic protection, not comprehensive security */
+    const char *dangerous = "`$;|&><";
+    for (const char *p = command; *p; p++) {
+        for (const char *d = dangerous; *d; d++) {
+            if (*p == *d) {
+                return 0;  /* Potentially dangerous */
+            }
+        }
+    }
+
+    return 1;  /* Appears safe */
+}

--- a/tests/test_command_runner.c
+++ b/tests/test_command_runner.c
@@ -1,0 +1,213 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "test.h"
+#include "../include/canvas.h"
+#include "../include/command_runner.h"
+
+int main(void) {
+    TEST_START();
+
+    TEST("command_runner_set_command - Basic set") {
+        Canvas canvas;
+        canvas_init(&canvas, 1000.0, 1000.0);
+
+        int box_id = canvas_add_box(&canvas, 10.0, 20.0, 30, 10, "Test Box");
+        Box *box = canvas_get_box(&canvas, box_id);
+
+        int result = command_runner_set_command(box, "echo hello");
+        ASSERT_EQ(result, 0, "Set command should succeed");
+        ASSERT_NOT_NULL(box->command, "Command should be set");
+        ASSERT_STR_EQ(box->command, "echo hello", "Command matches");
+        ASSERT_EQ(box->content_type, BOX_CONTENT_COMMAND, "Content type is COMMAND");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("command_runner_set_command - NULL parameters") {
+        Canvas canvas;
+        canvas_init(&canvas, 1000.0, 1000.0);
+
+        int box_id = canvas_add_box(&canvas, 10.0, 20.0, 30, 10, "Test Box");
+        Box *box = canvas_get_box(&canvas, box_id);
+
+        int result = command_runner_set_command(NULL, "echo hello");
+        ASSERT_EQ(result, -1, "NULL box should fail");
+
+        result = command_runner_set_command(box, NULL);
+        ASSERT_EQ(result, -1, "NULL command should fail");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("command_runner_execute - Simple echo") {
+        Canvas canvas;
+        canvas_init(&canvas, 1000.0, 1000.0);
+
+        int box_id = canvas_add_box(&canvas, 10.0, 20.0, 30, 10, "Test Box");
+        Box *box = canvas_get_box(&canvas, box_id);
+
+        command_runner_set_command(box, "echo hello");
+        int exit_code = command_runner_execute(box);
+
+        ASSERT_EQ(exit_code, 0, "Echo should exit with 0");
+        ASSERT_EQ(box->content_type, BOX_CONTENT_COMMAND, "Content type is COMMAND");
+        ASSERT(box->content_lines > 0, "Should have output lines");
+
+        /* First line should contain "hello" (may have trailing space on Windows) */
+        if (box->content && box->content_lines > 0) {
+            ASSERT(strstr(box->content[0], "hello") != NULL, "First line contains hello");
+        }
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("command_runner_execute - Exit code captured") {
+        Canvas canvas;
+        canvas_init(&canvas, 1000.0, 1000.0);
+
+        int box_id = canvas_add_box(&canvas, 10.0, 20.0, 30, 10, "Test Box");
+        Box *box = canvas_get_box(&canvas, box_id);
+
+        /* Command that exits with 0 */
+        command_runner_set_command(box, "echo success");
+        int exit_code = command_runner_execute(box);
+        ASSERT_EQ(exit_code, 0, "Successful command exits with 0");
+
+        int stored_code = command_runner_get_exit_code(box);
+        ASSERT_EQ(stored_code, 0, "Stored exit code is 0");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("command_runner_execute - NULL box") {
+        int result = command_runner_execute(NULL);
+        ASSERT_EQ(result, -1, "NULL box should return -1");
+    }
+
+    TEST("command_runner_execute - No command set") {
+        Canvas canvas;
+        canvas_init(&canvas, 1000.0, 1000.0);
+
+        int box_id = canvas_add_box(&canvas, 10.0, 20.0, 30, 10, "Test Box");
+        Box *box = canvas_get_box(&canvas, box_id);
+
+        /* Don't set a command */
+        int result = command_runner_execute(box);
+        ASSERT_EQ(result, -1, "No command should return -1");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("command_runner_clear - Clears output") {
+        Canvas canvas;
+        canvas_init(&canvas, 1000.0, 1000.0);
+
+        int box_id = canvas_add_box(&canvas, 10.0, 20.0, 30, 10, "Test Box");
+        Box *box = canvas_get_box(&canvas, box_id);
+
+        command_runner_set_command(box, "echo hello");
+        command_runner_execute(box);
+
+        ASSERT(box->content_lines > 0, "Has output before clear");
+
+        command_runner_clear(box);
+
+        ASSERT_EQ(box->content_lines, 0, "No content after clear");
+        ASSERT_NULL(box->content, "Content is NULL after clear");
+        /* Command should still be set */
+        ASSERT_NOT_NULL(box->command, "Command preserved after clear");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("command_runner_clear - NULL box is safe") {
+        /* Should not crash */
+        command_runner_clear(NULL);
+        ASSERT(1, "NULL box handled safely");
+    }
+
+    TEST("command_runner_get_exit_code - Non-command box") {
+        Canvas canvas;
+        canvas_init(&canvas, 1000.0, 1000.0);
+
+        int box_id = canvas_add_box(&canvas, 10.0, 20.0, 30, 10, "Test Box");
+        Box *box = canvas_get_box(&canvas, box_id);
+
+        /* Box is TEXT type by default */
+        int exit_code = command_runner_get_exit_code(box);
+        ASSERT_EQ(exit_code, EXIT_CODE_UNKNOWN, "Non-command box returns unknown");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("command_runner_validate - Safe commands") {
+        ASSERT_EQ(command_runner_validate("echo hello"), 1, "echo hello is safe");
+        ASSERT_EQ(command_runner_validate("ls -la"), 1, "ls -la is safe");
+        ASSERT_EQ(command_runner_validate("make test"), 1, "make test is safe");
+        ASSERT_EQ(command_runner_validate("git status"), 1, "git status is safe");
+    }
+
+    TEST("command_runner_validate - Dangerous commands") {
+        ASSERT_EQ(command_runner_validate("echo $VAR"), 0, "$ is dangerous");
+        ASSERT_EQ(command_runner_validate("echo `cmd`"), 0, "Backtick is dangerous");
+        ASSERT_EQ(command_runner_validate("cmd1 | cmd2"), 0, "Pipe is dangerous");
+        ASSERT_EQ(command_runner_validate("cmd1 && cmd2"), 0, "And is dangerous");
+        ASSERT_EQ(command_runner_validate("cmd1 ; cmd2"), 0, "Semicolon is dangerous");
+        ASSERT_EQ(command_runner_validate("cmd > file"), 0, "Redirect is dangerous");
+    }
+
+    TEST("command_runner_validate - NULL and empty") {
+        ASSERT_EQ(command_runner_validate(NULL), 0, "NULL is invalid");
+        ASSERT_EQ(command_runner_validate(""), 0, "Empty is invalid");
+    }
+
+    TEST("command_runner_execute - Re-run replaces content") {
+        Canvas canvas;
+        canvas_init(&canvas, 1000.0, 1000.0);
+
+        int box_id = canvas_add_box(&canvas, 10.0, 20.0, 30, 10, "Test Box");
+        Box *box = canvas_get_box(&canvas, box_id);
+
+        /* First run */
+        command_runner_set_command(box, "echo first");
+        command_runner_execute(box);
+        int first_lines = box->content_lines;
+        ASSERT(first_lines > 0, "First run has output");
+
+        /* Second run - should replace content */
+        command_runner_execute(box);
+        ASSERT(box->content_lines > 0, "Second run has output");
+
+        /* Check first line contains "first" (command unchanged, may have trailing space) */
+        if (box->content && box->content_lines > 0) {
+            ASSERT(strstr(box->content[0], "first") != NULL, "Re-run output contains first");
+        }
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("command_runner - Multi-line output") {
+        Canvas canvas;
+        canvas_init(&canvas, 1000.0, 1000.0);
+
+        int box_id = canvas_add_box(&canvas, 10.0, 20.0, 30, 10, "Test Box");
+        Box *box = canvas_get_box(&canvas, box_id);
+
+        /* Command with multiple lines of output */
+#ifdef _WIN32
+        command_runner_set_command(box, "echo line1 & echo line2 & echo line3");
+#else
+        command_runner_set_command(box, "echo line1; echo line2; echo line3");
+#endif
+        command_runner_execute(box);
+
+        /* Should have at least 3 output lines plus exit code line */
+        ASSERT(box->content_lines >= 3, "Should have multiple output lines");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST_END();
+}


### PR DESCRIPTION
## Summary
Implement shell command execution allowing boxes to run commands and display their output. This adds `:run` and `:rerun` commands plus `r` key support in focus mode for re-execution.

Fixes #56

This is Phase 3 of #19 (File/process association with popup output)

## Changes
- Add `command_runner.h/c` with execute, set_command, get_exit_code, clear, validate functions
- Add `:run <command>` command to execute shell commands in selected box
- Add `:rerun` command to re-execute command in command boxes
- Add `r` key in focus mode to re-run commands or reload files
- Capture both stdout and stderr (combined output)
- Store and display exit code

## New Commands
- `:run <command>` - Execute command in selected box (sets content_type to COMMAND)
- `:rerun` - Re-execute command for command boxes
- `r` key in focus mode - Re-run command or reload file

## Security
- Basic validation to detect dangerous shell metacharacters (`$`, backtick, `|`, `&`, `;`, `>`, `<`)
- Uses `popen()` with explicit stderr redirect

## Testing
- [x] All tests pass (`make test`)
- [x] New test suite `test_command_runner.c` with 36 assertions
- [x] Build succeeds on Windows (Git Bash)

## Type
- [x] New feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)