### PR TITLE
Fix color documentation comments (Issue #66)

### DIFF
--- a/connectors/jcaldwell-labs2canvas
+++ b/connectors/jcaldwell-labs2canvas
@@ -51,7 +51,7 @@ trap "rm -f $TMP_CANVAS" EXIT
     "  - Full-text search" \
     "  - Time-range filters"
 
-# MVP Complete (Blue - Color 4)
+# MVP Complete (Yellow - Color 4)
 "$CLI" add "$TMP_CANVAS" \
     --x 600 --y 200 \
     --width 35 --height 12 \
@@ -69,7 +69,7 @@ trap "rm -f $TMP_CANVAS" EXIT
     "  - Save/load JSON" \
     "  - Multiple canvases"
 
-# Active Development (Yellow - Color 3)
+# Active Development (Blue - Color 3)
 "$CLI" add "$TMP_CANVAS" \
     --x 1000 --y 200 \
     --width 35 --height 12 \


### PR DESCRIPTION
## Summary
Fix swapped color index comments in jcaldwell-labs2canvas connector. The comments said Blue=4/Yellow=3, but the actual color mapping in render.c is Blue=3/Yellow=4.

Fixes #66

## Changes
- Updated comment on line 54: `Blue - Color 4` → `Yellow - Color 4`
- Updated comment on line 72: `Yellow - Color 3` → `Blue - Color 3`

## Testing
- [x] All tests pass (`make test`)
- [x] Comments now match actual color indices in render.c

## Type
- [x] Bug fix (documentation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)