### PR TITLE
feat: Add undo/redo and inline text editing (Issues #79, #81)

### DIFF
--- a/include/canvas.h
+++ b/include/canvas.h
@@ -12,6 +12,10 @@ void canvas_cleanup(Canvas *canvas);
 /* Add a box to the canvas (returns box ID, or -1 on error) */
 int canvas_add_box(Canvas *canvas, double x, double y, int width, int height, const char *title);
 
+/* Restore a box with a specific ID (for undo/redo - skips grid snap, preserves ID) */
+int canvas_restore_box_with_id(Canvas *canvas, int box_id, double x, double y,
+                               int width, int height, const char *title);
+
 /* Add content lines to a box by ID */
 int canvas_add_box_content(Canvas *canvas, int box_id, const char **lines, int count);
 

--- a/include/canvas.h
+++ b/include/canvas.h
@@ -67,6 +67,10 @@ int canvas_calc_proportional_size(const Canvas *canvas, double x, double y,
 /* Add a connection between two boxes (returns connection ID, or -1 on error) */
 int canvas_add_connection(Canvas *canvas, int source_id, int dest_id);
 
+/* Restore a connection with specific ID and color (for undo/redo) */
+int canvas_restore_connection_with_id(Canvas *canvas, int conn_id, int source_id,
+                                      int dest_id, int color);
+
 /* Remove a connection by ID (returns 0 on success, -1 if not found) */
 int canvas_remove_connection(Canvas *canvas, int conn_id);
 

--- a/include/editor.h
+++ b/include/editor.h
@@ -1,0 +1,55 @@
+#ifndef EDITOR_H
+#define EDITOR_H
+
+#include "types.h"
+
+/* ============================================================
+ * Text Editing Functions (Issue #79)
+ * ============================================================ */
+
+/* Initialize editor state */
+void editor_init(TextEditor *editor);
+
+/* Cleanup editor state (frees original string) */
+void editor_cleanup(TextEditor *editor);
+
+/* Start editing a box's title */
+int editor_start_title(Canvas *canvas, int box_id);
+
+/* Cancel editing and restore original value */
+void editor_cancel(Canvas *canvas);
+
+/* Confirm editing and apply changes */
+int editor_confirm(Canvas *canvas);
+
+/* Insert a character at cursor position */
+int editor_insert_char(TextEditor *editor, char c);
+
+/* Delete character before cursor (backspace) */
+int editor_backspace(TextEditor *editor);
+
+/* Delete character at cursor (delete key) */
+int editor_delete(TextEditor *editor);
+
+/* Move cursor left */
+void editor_cursor_left(TextEditor *editor);
+
+/* Move cursor right */
+void editor_cursor_right(TextEditor *editor);
+
+/* Move cursor to start of line */
+void editor_cursor_home(TextEditor *editor);
+
+/* Move cursor to end of line */
+void editor_cursor_end(TextEditor *editor);
+
+/* Check if editor is active */
+bool editor_is_active(const Canvas *canvas);
+
+/* Get the current edit buffer for rendering */
+const char* editor_get_buffer(const TextEditor *editor);
+
+/* Get cursor position for rendering */
+int editor_get_cursor_pos(const TextEditor *editor);
+
+#endif /* EDITOR_H */

--- a/include/input_unified.h
+++ b/include/input_unified.h
@@ -77,7 +77,16 @@ typedef enum {
     
     /* Help overlay (Issue #34) */
     ACTION_TOGGLE_HELP,     /* Toggle help overlay visibility */
-    
+
+    /* Undo/Redo (Issue #81) */
+    ACTION_UNDO,            /* Undo last operation */
+    ACTION_REDO,            /* Redo last undone operation */
+
+    /* Text Editing (Issue #79) */
+    ACTION_EDIT_TITLE,      /* Start editing box title (e or Enter) */
+    ACTION_EDIT_CONFIRM,    /* Confirm edit (Enter when in edit mode) */
+    ACTION_EDIT_CANCEL,     /* Cancel edit (Escape when in edit mode) */
+
     /* Application control */
     ACTION_QUIT,            /* Quit application */
     
@@ -130,6 +139,8 @@ typedef enum {
 
 /* Keyboard control codes */
 #define CTRL_D 4
+#define CTRL_R 18
+#define CTRL_Z 26
 
 /*
  * Process keyboard input and translate to canvas actions

--- a/include/render.h
+++ b/include/render.h
@@ -50,4 +50,7 @@ void render_help_overlay(void);
 /* Render command line input (Issue #55) */
 void render_command_line(const Canvas *canvas);
 
+/* Render text edit mode overlay (Issue #79) */
+void render_edit_mode(const Canvas *canvas, const Viewport *vp);
+
 #endif /* RENDER_H */

--- a/include/undo.h
+++ b/include/undo.h
@@ -1,0 +1,74 @@
+#ifndef UNDO_H
+#define UNDO_H
+
+#include "types.h"
+
+/* Canvas is already defined in types.h, no forward declaration needed */
+
+/* ============================================================
+ * Undo Stack Management (Issue #81)
+ * ============================================================ */
+
+/* Initialize undo stack with default settings */
+void undo_stack_init(UndoStack *stack);
+
+/* Free all memory in the undo stack */
+void undo_stack_cleanup(UndoStack *stack);
+
+/* ============================================================
+ * Recording Operations
+ * ============================================================ */
+
+/* Record a box creation operation */
+void undo_record_box_create(Canvas *canvas, int box_id);
+
+/* Record a box deletion operation (captures full box state before delete) */
+void undo_record_box_delete(Canvas *canvas, int box_id);
+
+/* Record a box move operation */
+void undo_record_box_move(Canvas *canvas, int box_id,
+                          double old_x, double old_y,
+                          double new_x, double new_y);
+
+/* Record a box resize operation */
+void undo_record_box_resize(Canvas *canvas, int box_id,
+                            int old_width, int old_height,
+                            int new_width, int new_height);
+
+/* Record a box title change */
+void undo_record_box_title(Canvas *canvas, int box_id,
+                           const char *old_title, const char *new_title);
+
+/* Record a box color change */
+void undo_record_box_color(Canvas *canvas, int box_id,
+                           int old_color, int new_color);
+
+/* Record a connection creation */
+void undo_record_connection_create(Canvas *canvas, int conn_id);
+
+/* Record a connection deletion */
+void undo_record_connection_delete(Canvas *canvas, int conn_id);
+
+/* ============================================================
+ * Undo/Redo Operations
+ * ============================================================ */
+
+/* Perform undo operation. Returns true if undo was performed. */
+bool canvas_undo(Canvas *canvas);
+
+/* Perform redo operation. Returns true if redo was performed. */
+bool canvas_redo(Canvas *canvas);
+
+/* Check if undo is available */
+bool canvas_can_undo(const Canvas *canvas);
+
+/* Check if redo is available */
+bool canvas_can_redo(const Canvas *canvas);
+
+/* Get description of next undo operation (for status display) */
+const char* canvas_get_undo_description(const Canvas *canvas);
+
+/* Get description of next redo operation (for status display) */
+const char* canvas_get_redo_description(const Canvas *canvas);
+
+#endif /* UNDO_H */

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -3,6 +3,8 @@
 #include <string.h>
 #include <math.h>
 #include "canvas.h"
+#include "undo.h"
+#include "editor.h"
 
 /* Initialize canvas with dynamic memory allocation */
 int canvas_init(Canvas *canvas, double world_width, double world_height) {
@@ -69,6 +71,12 @@ int canvas_init(Canvas *canvas, double world_width, double world_height) {
     /* Initialize canvas metadata */
     canvas->filename = NULL;
 
+    /* Initialize undo/redo stack (Issue #81) */
+    undo_stack_init(&canvas->undo_stack);
+
+    /* Initialize text editor (Issue #79) */
+    editor_init(&canvas->editor);
+
     return 0;
 }
 
@@ -120,6 +128,12 @@ void canvas_cleanup(Canvas *canvas) {
         free(canvas->filename);
         canvas->filename = NULL;
     }
+
+    /* Free undo/redo stack (Issue #81) */
+    undo_stack_cleanup(&canvas->undo_stack);
+
+    /* Free text editor (Issue #79) */
+    editor_cleanup(&canvas->editor);
 }
 
 /* Grow the box array if needed */

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -185,6 +185,42 @@ int canvas_add_box(Canvas *canvas, double x, double y, int width, int height, co
     return box->id;
 }
 
+/* Restore a box with a specific ID (for undo/redo) */
+int canvas_restore_box_with_id(Canvas *canvas, int box_id, double x, double y,
+                               int width, int height, const char *title) {
+    if (canvas_ensure_capacity(canvas) != 0) {
+        return -1;
+    }
+
+    /* Don't apply grid snap - restore exact position */
+    Box *box = &canvas->boxes[canvas->box_count];
+    box->x = x;
+    box->y = y;
+    box->width = width;
+    box->height = height;
+    box->title = title ? strdup(title) : NULL;
+    box->content = NULL;
+    box->content_lines = 0;
+    box->selected = false;
+    box->id = box_id;  /* Use specified ID instead of next_id */
+    box->color = BOX_COLOR_DEFAULT;
+    box->box_type = BOX_TYPE_NOTE;
+
+    /* Initialize content source fields */
+    box->content_type = BOX_CONTENT_TEXT;
+    box->file_path = NULL;
+    box->command = NULL;
+
+    canvas->box_count++;
+
+    /* Ensure next_id stays ahead of restored IDs */
+    if (box_id >= canvas->next_id) {
+        canvas->next_id = box_id + 1;
+    }
+
+    return box->id;
+}
+
 /* Add content lines to a box by ID */
 int canvas_add_box_content(Canvas *canvas, int box_id, const char **lines, int count) {
     for (int i = 0; i < canvas->box_count; i++) {

--- a/src/editor.c
+++ b/src/editor.c
@@ -1,0 +1,220 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdlib.h>
+#include <string.h>
+#include "editor.h"
+#include "canvas.h"
+#include "undo.h"
+
+/* ============================================================
+ * Editor Initialization and Cleanup
+ * ============================================================ */
+
+void editor_init(TextEditor *editor) {
+    if (!editor) return;
+
+    editor->active = false;
+    editor->target = EDIT_NONE;
+    editor->box_id = -1;
+    editor->buffer[0] = '\0';
+    editor->cursor_pos = 0;
+    editor->length = 0;
+    editor->original = NULL;
+}
+
+void editor_cleanup(TextEditor *editor) {
+    if (!editor) return;
+
+    if (editor->original) {
+        free(editor->original);
+        editor->original = NULL;
+    }
+
+    editor->active = false;
+    editor->target = EDIT_NONE;
+    editor->box_id = -1;
+    editor->buffer[0] = '\0';
+    editor->cursor_pos = 0;
+    editor->length = 0;
+}
+
+/* ============================================================
+ * Edit Mode Management
+ * ============================================================ */
+
+int editor_start_title(Canvas *canvas, int box_id) {
+    if (!canvas) return -1;
+
+    Box *box = canvas_get_box(canvas, box_id);
+    if (!box) return -1;
+
+    TextEditor *editor = &canvas->editor;
+
+    /* Clean up any previous edit state */
+    editor_cleanup(editor);
+
+    /* Save original value for cancel */
+    if (box->title) {
+        editor->original = strdup(box->title);
+    } else {
+        editor->original = strdup("");
+    }
+
+    if (!editor->original) return -1;
+
+    /* Initialize edit buffer with current title */
+    size_t title_len = box->title ? strlen(box->title) : 0;
+    if (title_len >= MAX_TITLE_LENGTH) {
+        title_len = MAX_TITLE_LENGTH - 1;
+    }
+
+    if (box->title) {
+        strncpy(editor->buffer, box->title, MAX_TITLE_LENGTH - 1);
+        editor->buffer[MAX_TITLE_LENGTH - 1] = '\0';
+    } else {
+        editor->buffer[0] = '\0';
+    }
+
+    editor->length = (int)strlen(editor->buffer);
+    editor->cursor_pos = editor->length;  /* Start at end */
+    editor->box_id = box_id;
+    editor->target = EDIT_TITLE;
+    editor->active = true;
+
+    return 0;
+}
+
+void editor_cancel(Canvas *canvas) {
+    if (!canvas) return;
+
+    TextEditor *editor = &canvas->editor;
+    if (!editor->active) return;
+
+    /* Restore original value if editing title */
+    if (editor->target == EDIT_TITLE && editor->original) {
+        Box *box = canvas_get_box(canvas, editor->box_id);
+        if (box) {
+            free(box->title);
+            box->title = strdup(editor->original);
+        }
+    }
+
+    editor_cleanup(editor);
+}
+
+int editor_confirm(Canvas *canvas) {
+    if (!canvas) return -1;
+
+    TextEditor *editor = &canvas->editor;
+    if (!editor->active) return -1;
+
+    if (editor->target == EDIT_TITLE) {
+        Box *box = canvas_get_box(canvas, editor->box_id);
+        if (box) {
+            /* Record for undo before changing */
+            undo_record_box_title(canvas, editor->box_id,
+                                  editor->original, editor->buffer);
+
+            /* Apply the new title */
+            free(box->title);
+            box->title = strdup(editor->buffer);
+        }
+    }
+
+    editor_cleanup(editor);
+    return 0;
+}
+
+/* ============================================================
+ * Text Manipulation
+ * ============================================================ */
+
+int editor_insert_char(TextEditor *editor, char c) {
+    if (!editor || !editor->active) return -1;
+    if (editor->length >= MAX_TITLE_LENGTH - 1) return -1;
+
+    /* Make room for new character */
+    memmove(&editor->buffer[editor->cursor_pos + 1],
+            &editor->buffer[editor->cursor_pos],
+            editor->length - editor->cursor_pos + 1);  /* +1 for null terminator */
+
+    editor->buffer[editor->cursor_pos] = c;
+    editor->cursor_pos++;
+    editor->length++;
+
+    return 0;
+}
+
+int editor_backspace(TextEditor *editor) {
+    if (!editor || !editor->active) return -1;
+    if (editor->cursor_pos <= 0) return -1;
+
+    /* Remove character before cursor */
+    memmove(&editor->buffer[editor->cursor_pos - 1],
+            &editor->buffer[editor->cursor_pos],
+            editor->length - editor->cursor_pos + 1);
+
+    editor->cursor_pos--;
+    editor->length--;
+
+    return 0;
+}
+
+int editor_delete(TextEditor *editor) {
+    if (!editor || !editor->active) return -1;
+    if (editor->cursor_pos >= editor->length) return -1;
+
+    /* Remove character at cursor */
+    memmove(&editor->buffer[editor->cursor_pos],
+            &editor->buffer[editor->cursor_pos + 1],
+            editor->length - editor->cursor_pos);
+
+    editor->length--;
+
+    return 0;
+}
+
+/* ============================================================
+ * Cursor Movement
+ * ============================================================ */
+
+void editor_cursor_left(TextEditor *editor) {
+    if (!editor || !editor->active) return;
+    if (editor->cursor_pos > 0) {
+        editor->cursor_pos--;
+    }
+}
+
+void editor_cursor_right(TextEditor *editor) {
+    if (!editor || !editor->active) return;
+    if (editor->cursor_pos < editor->length) {
+        editor->cursor_pos++;
+    }
+}
+
+void editor_cursor_home(TextEditor *editor) {
+    if (!editor || !editor->active) return;
+    editor->cursor_pos = 0;
+}
+
+void editor_cursor_end(TextEditor *editor) {
+    if (!editor || !editor->active) return;
+    editor->cursor_pos = editor->length;
+}
+
+/* ============================================================
+ * Utility Functions
+ * ============================================================ */
+
+bool editor_is_active(const Canvas *canvas) {
+    return canvas && canvas->editor.active;
+}
+
+const char* editor_get_buffer(const TextEditor *editor) {
+    if (!editor) return "";
+    return editor->buffer;
+}
+
+int editor_get_cursor_pos(const TextEditor *editor) {
+    if (!editor) return 0;
+    return editor->cursor_pos;
+}

--- a/src/editor.c
+++ b/src/editor.c
@@ -74,6 +74,7 @@ int editor_start_title(Canvas *canvas, int box_id) {
         editor->buffer[0] = '\0';
     }
 
+    /* Cast is safe: buffer is capped at MAX_TITLE_LENGTH (256), well within int range */
     editor->length = (int)strlen(editor->buffer);
     editor->cursor_pos = editor->length;  /* Start at end */
     editor->box_id = box_id;

--- a/src/input_unified.c
+++ b/src/input_unified.c
@@ -60,6 +60,13 @@ const char* input_unified_action_name(CanvasAction action) {
         case ACTION_ENTER_EDIT_MODE: return "ENTER_EDIT_MODE";
         case ACTION_ENTER_PARAM_MODE: return "ENTER_PARAM_MODE";
         case ACTION_ENTER_NAV_MODE:  return "ENTER_NAV_MODE";
+        case ACTION_TOGGLE_HELP:     return "TOGGLE_HELP";
+        case ACTION_UNDO:            return "UNDO";
+        case ACTION_REDO:            return "REDO";
+        case ACTION_EDIT_TITLE:      return "EDIT_TITLE";
+        case ACTION_EDIT_CONFIRM:    return "EDIT_CONFIRM";
+        case ACTION_EDIT_CANCEL:     return "EDIT_CANCEL";
+        case ACTION_CYCLE_BOX_TYPE:  return "CYCLE_BOX_TYPE";
         case ACTION_QUIT:            return "QUIT";
         default:                     return "UNKNOWN";
     }
@@ -240,10 +247,15 @@ int input_unified_process_keyboard(int ch, const Viewport *vp, InputEvent *event
             event->action = ACTION_START_CONNECTION;
             return INPUT_SOURCE_KEYBOARD;
 
-        /* Focus box (Phase 5b) */
-        case '\n':  /* Enter */
+        /* Text Editing (Issue #79) - Enter starts title editing */
+        case '\n':
         case '\r':
-        case ' ':   /* Space */
+        case KEY_ENTER:
+            event->action = ACTION_EDIT_TITLE;
+            return INPUT_SOURCE_KEYBOARD;
+
+        /* Focus box (Phase 5b) - Space enters focus mode */
+        case ' ':
             event->action = ACTION_FOCUS_BOX;
             return INPUT_SOURCE_KEYBOARD;
         
@@ -251,7 +263,17 @@ int input_unified_process_keyboard(int ch, const Viewport *vp, InputEvent *event
         case KEY_F(1):
             event->action = ACTION_TOGGLE_HELP;
             return INPUT_SOURCE_KEYBOARD;
-        
+
+        /* Undo/Redo (Issue #81) */
+        case 'u':
+        case CTRL_Z:
+            event->action = ACTION_UNDO;
+            return INPUT_SOURCE_KEYBOARD;
+
+        case CTRL_R:
+            event->action = ACTION_REDO;
+            return INPUT_SOURCE_KEYBOARD;
+
         /* Save canvas */
         case KEY_F(2):
             event->action = ACTION_SAVE_CANVAS;

--- a/src/main.c
+++ b/src/main.c
@@ -338,6 +338,9 @@ int main(int argc, char *argv[]) {
         /* Render command line if active (Issue #55) - after status bar */
         render_command_line(&canvas);
 
+        /* Render text edit mode overlay (Issue #79) */
+        render_edit_mode(&canvas, &viewport);
+
         /* Render test mode overlays (Issue #70) - on top of everything */
         if (test_mode.enabled) {
             test_mode_update_fps(&test_mode);

--- a/src/undo.c
+++ b/src/undo.c
@@ -1,0 +1,577 @@
+#define _POSIX_C_SOURCE 200809L
+#include <stdlib.h>
+#include <string.h>
+#include "undo.h"
+#include "canvas.h"
+
+/* ============================================================
+ * Helper Functions
+ * ============================================================ */
+
+/* Safe string duplication */
+static char *safe_strdup(const char *s) {
+    if (s == NULL) return NULL;
+    return strdup(s);
+}
+
+/* Deep copy content array */
+static char **copy_content(char **content, int count) {
+    if (content == NULL || count <= 0) return NULL;
+
+    char **copy = malloc(sizeof(char *) * count);
+    if (copy == NULL) return NULL;
+
+    for (int i = 0; i < count; i++) {
+        copy[i] = safe_strdup(content[i]);
+        if (content[i] != NULL && copy[i] == NULL) {
+            /* Cleanup on failure */
+            for (int j = 0; j < i; j++) {
+                free(copy[j]);
+            }
+            free(copy);
+            return NULL;
+        }
+    }
+    return copy;
+}
+
+/* Free content array */
+static void free_content(char **content, int count) {
+    if (content == NULL) return;
+    for (int i = 0; i < count; i++) {
+        free(content[i]);
+    }
+    free(content);
+}
+
+/* Create a snapshot of a box */
+static void snapshot_box(BoxSnapshot *snap, const Box *box) {
+    snap->id = box->id;
+    snap->x = box->x;
+    snap->y = box->y;
+    snap->width = box->width;
+    snap->height = box->height;
+    snap->title = safe_strdup(box->title);
+    snap->content = copy_content(box->content, box->content_lines);
+    snap->content_lines = box->content_lines;
+    snap->color = box->color;
+    snap->box_type = box->box_type;
+    snap->content_type = box->content_type;
+    snap->file_path = safe_strdup(box->file_path);
+    snap->command = safe_strdup(box->command);
+}
+
+/* Free a box snapshot */
+static void free_box_snapshot(BoxSnapshot *snap) {
+    free(snap->title);
+    free_content(snap->content, snap->content_lines);
+    free(snap->file_path);
+    free(snap->command);
+    /* Zero out to prevent double-free */
+    memset(snap, 0, sizeof(BoxSnapshot));
+}
+
+/* Create a snapshot of a connection */
+static void snapshot_connection(ConnectionSnapshot *snap, const Connection *conn) {
+    snap->id = conn->id;
+    snap->source_id = conn->source_id;
+    snap->dest_id = conn->dest_id;
+    snap->color = conn->color;
+}
+
+/* Free a single operation */
+static void free_operation(Operation *op) {
+    if (op == NULL) return;
+
+    /* Free box snapshots based on operation type */
+    switch (op->type) {
+        case OP_BOX_CREATE:
+            free_box_snapshot(&op->after.box_after);
+            break;
+        case OP_BOX_DELETE:
+            free_box_snapshot(&op->before.box_before);
+            break;
+        case OP_BOX_MOVE:
+        case OP_BOX_RESIZE:
+        case OP_BOX_COLOR:
+            /* These only store position/size/color, no pointers */
+            break;
+        case OP_BOX_TITLE:
+            free(op->before.box_before.title);
+            free(op->after.box_after.title);
+            break;
+        case OP_BOX_CONTENT:
+            free_content(op->before.box_before.content, op->before.box_before.content_lines);
+            free_content(op->after.box_after.content, op->after.box_after.content_lines);
+            break;
+        case OP_CONNECTION_CREATE:
+        case OP_CONNECTION_DELETE:
+            /* ConnectionSnapshot has no pointers */
+            break;
+    }
+
+    free(op);
+}
+
+/* Free the redo chain */
+static void free_redo_chain(UndoStack *stack) {
+    Operation *op = stack->redo_head;
+    while (op != NULL) {
+        Operation *next = op->next;
+        free_operation(op);
+        op = next;
+    }
+    stack->redo_head = NULL;
+}
+
+/* Trim undo stack to max size */
+static void trim_undo_stack(UndoStack *stack) {
+    while (stack->size > stack->max_size && stack->current != NULL) {
+        /* Find the oldest operation */
+        Operation *oldest = stack->current;
+        while (oldest->prev != NULL) {
+            oldest = oldest->prev;
+        }
+
+        /* Remove it */
+        if (oldest->next != NULL) {
+            oldest->next->prev = NULL;
+        }
+        free_operation(oldest);
+        stack->size--;
+    }
+}
+
+/* Push a new operation onto the undo stack */
+static Operation* push_operation(Canvas *canvas, OpType type, int box_id, int conn_id) {
+    UndoStack *stack = &canvas->undo_stack;
+
+    /* When a new operation is recorded, discard the redo chain */
+    free_redo_chain(stack);
+
+    Operation *op = malloc(sizeof(Operation));
+    if (op == NULL) return NULL;
+
+    memset(op, 0, sizeof(Operation));
+    op->type = type;
+    op->box_id = box_id;
+    op->conn_id = conn_id;
+
+    /* Link to existing chain */
+    op->prev = stack->current;
+    op->next = NULL;
+
+    if (stack->current != NULL) {
+        stack->current->next = op;
+    }
+
+    stack->current = op;
+    stack->size++;
+
+    /* Trim if we exceed max size */
+    trim_undo_stack(stack);
+
+    return op;
+}
+
+/* ============================================================
+ * Stack Management
+ * ============================================================ */
+
+void undo_stack_init(UndoStack *stack) {
+    stack->current = NULL;
+    stack->redo_head = NULL;
+    stack->size = 0;
+    stack->max_size = UNDO_STACK_MAX_SIZE;
+}
+
+void undo_stack_cleanup(UndoStack *stack) {
+    /* Free redo chain */
+    free_redo_chain(stack);
+
+    /* Free undo chain */
+    Operation *op = stack->current;
+    while (op != NULL) {
+        Operation *prev = op->prev;
+        free_operation(op);
+        op = prev;
+    }
+
+    stack->current = NULL;
+    stack->size = 0;
+}
+
+/* ============================================================
+ * Recording Operations
+ * ============================================================ */
+
+void undo_record_box_create(Canvas *canvas, int box_id) {
+    Box *box = canvas_get_box(canvas, box_id);
+    if (box == NULL) return;
+
+    Operation *op = push_operation(canvas, OP_BOX_CREATE, box_id, -1);
+    if (op == NULL) return;
+
+    /* Store the created box state for redo */
+    snapshot_box(&op->after.box_after, box);
+}
+
+void undo_record_box_delete(Canvas *canvas, int box_id) {
+    Box *box = canvas_get_box(canvas, box_id);
+    if (box == NULL) return;
+
+    Operation *op = push_operation(canvas, OP_BOX_DELETE, box_id, -1);
+    if (op == NULL) return;
+
+    /* Store the box state before deletion for undo */
+    snapshot_box(&op->before.box_before, box);
+}
+
+void undo_record_box_move(Canvas *canvas, int box_id,
+                          double old_x, double old_y,
+                          double new_x, double new_y) {
+    Operation *op = push_operation(canvas, OP_BOX_MOVE, box_id, -1);
+    if (op == NULL) return;
+
+    op->before.box_before.id = box_id;
+    op->before.box_before.x = old_x;
+    op->before.box_before.y = old_y;
+
+    op->after.box_after.id = box_id;
+    op->after.box_after.x = new_x;
+    op->after.box_after.y = new_y;
+}
+
+void undo_record_box_resize(Canvas *canvas, int box_id,
+                            int old_width, int old_height,
+                            int new_width, int new_height) {
+    Operation *op = push_operation(canvas, OP_BOX_RESIZE, box_id, -1);
+    if (op == NULL) return;
+
+    op->before.box_before.id = box_id;
+    op->before.box_before.width = old_width;
+    op->before.box_before.height = old_height;
+
+    op->after.box_after.id = box_id;
+    op->after.box_after.width = new_width;
+    op->after.box_after.height = new_height;
+}
+
+void undo_record_box_title(Canvas *canvas, int box_id,
+                           const char *old_title, const char *new_title) {
+    Operation *op = push_operation(canvas, OP_BOX_TITLE, box_id, -1);
+    if (op == NULL) return;
+
+    op->before.box_before.id = box_id;
+    op->before.box_before.title = safe_strdup(old_title);
+
+    op->after.box_after.id = box_id;
+    op->after.box_after.title = safe_strdup(new_title);
+}
+
+void undo_record_box_color(Canvas *canvas, int box_id,
+                           int old_color, int new_color) {
+    Operation *op = push_operation(canvas, OP_BOX_COLOR, box_id, -1);
+    if (op == NULL) return;
+
+    op->before.box_before.id = box_id;
+    op->before.box_before.color = old_color;
+
+    op->after.box_after.id = box_id;
+    op->after.box_after.color = new_color;
+}
+
+void undo_record_connection_create(Canvas *canvas, int conn_id) {
+    Connection *conn = canvas_get_connection(canvas, conn_id);
+    if (conn == NULL) return;
+
+    Operation *op = push_operation(canvas, OP_CONNECTION_CREATE, -1, conn_id);
+    if (op == NULL) return;
+
+    snapshot_connection(&op->after.conn_after, conn);
+}
+
+void undo_record_connection_delete(Canvas *canvas, int conn_id) {
+    Connection *conn = canvas_get_connection(canvas, conn_id);
+    if (conn == NULL) return;
+
+    Operation *op = push_operation(canvas, OP_CONNECTION_DELETE, -1, conn_id);
+    if (op == NULL) return;
+
+    snapshot_connection(&op->before.conn_before, conn);
+}
+
+/* ============================================================
+ * Undo/Redo Execution
+ * ============================================================ */
+
+/* Restore a box from snapshot (used by both undo delete and redo create) */
+static int restore_box_from_snapshot(Canvas *canvas, const BoxSnapshot *snap) {
+    /* Add the box back */
+    int new_id = canvas_add_box(canvas, snap->x, snap->y,
+                                snap->width, snap->height, snap->title);
+    if (new_id < 0) return -1;
+
+    Box *box = canvas_get_box(canvas, new_id);
+    if (box == NULL) return -1;
+
+    /* Restore additional properties */
+    box->color = snap->color;
+    box->box_type = snap->box_type;
+    box->content_type = snap->content_type;
+
+    /* Restore content */
+    if (snap->content != NULL && snap->content_lines > 0) {
+        canvas_add_box_content(canvas, new_id,
+                               (const char **)snap->content, snap->content_lines);
+    }
+
+    /* Restore file_path and command */
+    if (snap->file_path) {
+        box->file_path = safe_strdup(snap->file_path);
+    }
+    if (snap->command) {
+        box->command = safe_strdup(snap->command);
+    }
+
+    return new_id;
+}
+
+bool canvas_undo(Canvas *canvas) {
+    if (canvas == NULL) return false;
+
+    UndoStack *stack = &canvas->undo_stack;
+    if (stack->current == NULL) return false;
+
+    Operation *op = stack->current;
+
+    switch (op->type) {
+        case OP_BOX_CREATE: {
+            /* Undo create = delete the box */
+            canvas_remove_box(canvas, op->box_id);
+            break;
+        }
+
+        case OP_BOX_DELETE: {
+            /* Undo delete = recreate the box */
+            restore_box_from_snapshot(canvas, &op->before.box_before);
+            break;
+        }
+
+        case OP_BOX_MOVE: {
+            /* Undo move = restore old position */
+            Box *box = canvas_get_box(canvas, op->box_id);
+            if (box) {
+                box->x = op->before.box_before.x;
+                box->y = op->before.box_before.y;
+            }
+            break;
+        }
+
+        case OP_BOX_RESIZE: {
+            /* Undo resize = restore old dimensions */
+            Box *box = canvas_get_box(canvas, op->box_id);
+            if (box) {
+                box->width = op->before.box_before.width;
+                box->height = op->before.box_before.height;
+            }
+            break;
+        }
+
+        case OP_BOX_TITLE: {
+            /* Undo title change = restore old title */
+            Box *box = canvas_get_box(canvas, op->box_id);
+            if (box) {
+                free(box->title);
+                box->title = safe_strdup(op->before.box_before.title);
+            }
+            break;
+        }
+
+        case OP_BOX_CONTENT: {
+            /* Undo content change = restore old content */
+            Box *box = canvas_get_box(canvas, op->box_id);
+            if (box) {
+                free_content(box->content, box->content_lines);
+                box->content = copy_content(op->before.box_before.content,
+                                            op->before.box_before.content_lines);
+                box->content_lines = op->before.box_before.content_lines;
+            }
+            break;
+        }
+
+        case OP_BOX_COLOR: {
+            /* Undo color change = restore old color */
+            Box *box = canvas_get_box(canvas, op->box_id);
+            if (box) {
+                box->color = op->before.box_before.color;
+            }
+            break;
+        }
+
+        case OP_CONNECTION_CREATE: {
+            /* Undo create connection = remove connection */
+            canvas_remove_connection(canvas, op->conn_id);
+            break;
+        }
+
+        case OP_CONNECTION_DELETE: {
+            /* Undo delete connection = recreate it */
+            ConnectionSnapshot *snap = &op->before.conn_before;
+            canvas_add_connection(canvas, snap->source_id, snap->dest_id);
+            break;
+        }
+    }
+
+    /* Move current operation to redo chain */
+    stack->current = op->prev;
+    if (stack->current) {
+        stack->current->next = NULL;
+    }
+    stack->size--;
+
+    /* Add to redo chain */
+    op->prev = NULL;
+    op->next = stack->redo_head;
+    if (stack->redo_head) {
+        stack->redo_head->prev = op;
+    }
+    stack->redo_head = op;
+
+    return true;
+}
+
+bool canvas_redo(Canvas *canvas) {
+    if (canvas == NULL) return false;
+
+    UndoStack *stack = &canvas->undo_stack;
+    if (stack->redo_head == NULL) return false;
+
+    Operation *op = stack->redo_head;
+
+    switch (op->type) {
+        case OP_BOX_CREATE: {
+            /* Redo create = recreate the box */
+            restore_box_from_snapshot(canvas, &op->after.box_after);
+            break;
+        }
+
+        case OP_BOX_DELETE: {
+            /* Redo delete = delete the box again */
+            canvas_remove_box(canvas, op->box_id);
+            break;
+        }
+
+        case OP_BOX_MOVE: {
+            /* Redo move = apply new position */
+            Box *box = canvas_get_box(canvas, op->box_id);
+            if (box) {
+                box->x = op->after.box_after.x;
+                box->y = op->after.box_after.y;
+            }
+            break;
+        }
+
+        case OP_BOX_RESIZE: {
+            /* Redo resize = apply new dimensions */
+            Box *box = canvas_get_box(canvas, op->box_id);
+            if (box) {
+                box->width = op->after.box_after.width;
+                box->height = op->after.box_after.height;
+            }
+            break;
+        }
+
+        case OP_BOX_TITLE: {
+            /* Redo title change = apply new title */
+            Box *box = canvas_get_box(canvas, op->box_id);
+            if (box) {
+                free(box->title);
+                box->title = safe_strdup(op->after.box_after.title);
+            }
+            break;
+        }
+
+        case OP_BOX_CONTENT: {
+            /* Redo content change = apply new content */
+            Box *box = canvas_get_box(canvas, op->box_id);
+            if (box) {
+                free_content(box->content, box->content_lines);
+                box->content = copy_content(op->after.box_after.content,
+                                            op->after.box_after.content_lines);
+                box->content_lines = op->after.box_after.content_lines;
+            }
+            break;
+        }
+
+        case OP_BOX_COLOR: {
+            /* Redo color change = apply new color */
+            Box *box = canvas_get_box(canvas, op->box_id);
+            if (box) {
+                box->color = op->after.box_after.color;
+            }
+            break;
+        }
+
+        case OP_CONNECTION_CREATE: {
+            /* Redo create connection = create it again */
+            ConnectionSnapshot *snap = &op->after.conn_after;
+            canvas_add_connection(canvas, snap->source_id, snap->dest_id);
+            break;
+        }
+
+        case OP_CONNECTION_DELETE: {
+            /* Redo delete connection = remove it again */
+            canvas_remove_connection(canvas, op->conn_id);
+            break;
+        }
+    }
+
+    /* Remove from redo chain */
+    stack->redo_head = op->next;
+    if (stack->redo_head) {
+        stack->redo_head->prev = NULL;
+    }
+
+    /* Add back to undo chain */
+    op->next = NULL;
+    op->prev = stack->current;
+    if (stack->current) {
+        stack->current->next = op;
+    }
+    stack->current = op;
+    stack->size++;
+
+    return true;
+}
+
+bool canvas_can_undo(const Canvas *canvas) {
+    return canvas != NULL && canvas->undo_stack.current != NULL;
+}
+
+bool canvas_can_redo(const Canvas *canvas) {
+    return canvas != NULL && canvas->undo_stack.redo_head != NULL;
+}
+
+/* Operation type descriptions */
+static const char* op_type_descriptions[] = {
+    "create box",
+    "delete box",
+    "move box",
+    "resize box",
+    "change content",
+    "change title",
+    "change color",
+    "create connection",
+    "delete connection"
+};
+
+const char* canvas_get_undo_description(const Canvas *canvas) {
+    if (!canvas_can_undo(canvas)) return NULL;
+    return op_type_descriptions[canvas->undo_stack.current->type];
+}
+
+const char* canvas_get_redo_description(const Canvas *canvas) {
+    if (!canvas_can_redo(canvas)) return NULL;
+    return op_type_descriptions[canvas->undo_stack.redo_head->type];
+}

--- a/tests/test_editor.c
+++ b/tests/test_editor.c
@@ -198,10 +198,15 @@ int main(void) {
         /* Start editing */
         editor_start_title(&canvas, id);
 
-        /* Make changes */
-        canvas.editor.cursor_pos = 0;
-        canvas.editor.buffer[0] = '\0';
-        canvas.editor.length = 0;
+        /* Clear existing content using the public editor API */
+        editor_cursor_home(&canvas.editor);
+        const char *buf = editor_get_buffer(&canvas.editor);
+        size_t len = strlen(buf);
+        for (size_t i = 0; i < len; i++) {
+            editor_delete(&canvas.editor);
+        }
+
+        /* Insert new text */
         editor_insert_char(&canvas.editor, 'N');
         editor_insert_char(&canvas.editor, 'e');
         editor_insert_char(&canvas.editor, 'w');

--- a/tests/test_editor.c
+++ b/tests/test_editor.c
@@ -1,0 +1,241 @@
+#define _POSIX_C_SOURCE 200809L
+#include <string.h>
+#include "test.h"
+#include "../include/canvas.h"
+#include "../include/editor.h"
+#include "../include/undo.h"
+#include "../include/types.h"
+
+int main(void) {
+    TEST_START();
+
+    TEST("Editor initialization in canvas") {
+        Canvas canvas;
+        int result = canvas_init(&canvas, 200.0, 100.0);
+
+        ASSERT_EQ(result, 0, "canvas_init returns 0");
+        ASSERT(!editor_is_active(&canvas), "Editor not active on fresh canvas");
+        ASSERT_EQ(canvas.editor.target, EDIT_NONE, "No edit target");
+        ASSERT_EQ(canvas.editor.box_id, -1, "No box being edited");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Start title editing") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id = canvas_add_box(&canvas, 10.0, 20.0, 30, 5, "Original Title");
+        ASSERT(id > 0, "Box created");
+
+        int result = editor_start_title(&canvas, id);
+        ASSERT_EQ(result, 0, "Start edit succeeded");
+        ASSERT(editor_is_active(&canvas), "Editor is active");
+        ASSERT_EQ(canvas.editor.target, EDIT_TITLE, "Editing title");
+        ASSERT_EQ(canvas.editor.box_id, id, "Editing correct box");
+        ASSERT(strcmp(canvas.editor.buffer, "Original Title") == 0, "Buffer has title");
+        ASSERT_EQ(canvas.editor.cursor_pos, 14, "Cursor at end");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Insert character") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id = canvas_add_box(&canvas, 10.0, 20.0, 30, 5, "Test");
+        editor_start_title(&canvas, id);
+
+        /* Cursor is at end */
+        editor_insert_char(&canvas.editor, '!');
+        ASSERT(strcmp(canvas.editor.buffer, "Test!") == 0, "Appended character");
+        ASSERT_EQ(canvas.editor.cursor_pos, 5, "Cursor moved forward");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Insert character in middle") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id = canvas_add_box(&canvas, 10.0, 20.0, 30, 5, "AC");
+        editor_start_title(&canvas, id);
+
+        /* Move cursor to position 1 */
+        canvas.editor.cursor_pos = 1;
+        editor_insert_char(&canvas.editor, 'B');
+
+        ASSERT(strcmp(canvas.editor.buffer, "ABC") == 0, "Inserted in middle");
+        ASSERT_EQ(canvas.editor.cursor_pos, 2, "Cursor after inserted char");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Backspace") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id = canvas_add_box(&canvas, 10.0, 20.0, 30, 5, "Test!");
+        editor_start_title(&canvas, id);
+
+        editor_backspace(&canvas.editor);
+        ASSERT(strcmp(canvas.editor.buffer, "Test") == 0, "Removed last char");
+        ASSERT_EQ(canvas.editor.cursor_pos, 4, "Cursor moved back");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Delete at cursor") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id = canvas_add_box(&canvas, 10.0, 20.0, 30, 5, "ABCD");
+        editor_start_title(&canvas, id);
+
+        canvas.editor.cursor_pos = 1;  /* Cursor at 'B' */
+        editor_delete(&canvas.editor);
+
+        ASSERT(strcmp(canvas.editor.buffer, "ACD") == 0, "Deleted at cursor");
+        ASSERT_EQ(canvas.editor.cursor_pos, 1, "Cursor stayed in place");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Cursor movement") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id = canvas_add_box(&canvas, 10.0, 20.0, 30, 5, "Hello");
+        editor_start_title(&canvas, id);
+
+        ASSERT_EQ(canvas.editor.cursor_pos, 5, "Cursor at end");
+
+        editor_cursor_left(&canvas.editor);
+        ASSERT_EQ(canvas.editor.cursor_pos, 4, "Moved left");
+
+        editor_cursor_home(&canvas.editor);
+        ASSERT_EQ(canvas.editor.cursor_pos, 0, "At home");
+
+        editor_cursor_left(&canvas.editor);
+        ASSERT_EQ(canvas.editor.cursor_pos, 0, "Stayed at 0");
+
+        editor_cursor_right(&canvas.editor);
+        ASSERT_EQ(canvas.editor.cursor_pos, 1, "Moved right");
+
+        editor_cursor_end(&canvas.editor);
+        ASSERT_EQ(canvas.editor.cursor_pos, 5, "At end");
+
+        editor_cursor_right(&canvas.editor);
+        ASSERT_EQ(canvas.editor.cursor_pos, 5, "Stayed at end");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Cancel editing restores original") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id = canvas_add_box(&canvas, 10.0, 20.0, 30, 5, "Original");
+        editor_start_title(&canvas, id);
+
+        /* Modify the buffer */
+        editor_insert_char(&canvas.editor, '!');
+        ASSERT(strcmp(canvas.editor.buffer, "Original!") == 0, "Buffer modified");
+
+        /* Cancel */
+        editor_cancel(&canvas);
+
+        /* Check box title is restored */
+        Box *box = canvas_get_box(&canvas, id);
+        ASSERT(strcmp(box->title, "Original") == 0, "Title restored");
+        ASSERT(!editor_is_active(&canvas), "Editor deactivated");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Confirm editing applies changes") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id = canvas_add_box(&canvas, 10.0, 20.0, 30, 5, "Original");
+        editor_start_title(&canvas, id);
+
+        /* Modify the buffer */
+        editor_cursor_home(&canvas.editor);
+        editor_insert_char(&canvas.editor, 'N');
+        editor_insert_char(&canvas.editor, 'e');
+        editor_insert_char(&canvas.editor, 'w');
+        editor_insert_char(&canvas.editor, ' ');
+
+        /* Confirm */
+        editor_confirm(&canvas);
+
+        /* Check box title is changed */
+        Box *box = canvas_get_box(&canvas, id);
+        ASSERT(strcmp(box->title, "New Original") == 0, "Title changed");
+        ASSERT(!editor_is_active(&canvas), "Editor deactivated");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Start editing invalid box fails") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int result = editor_start_title(&canvas, 999);
+        ASSERT_EQ(result, -1, "Cannot edit non-existent box");
+        ASSERT(!editor_is_active(&canvas), "Editor not active");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Confirm with undo integration") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id = canvas_add_box(&canvas, 10.0, 20.0, 30, 5, "Original");
+
+        /* Start editing */
+        editor_start_title(&canvas, id);
+
+        /* Make changes */
+        canvas.editor.cursor_pos = 0;
+        canvas.editor.buffer[0] = '\0';
+        canvas.editor.length = 0;
+        editor_insert_char(&canvas.editor, 'N');
+        editor_insert_char(&canvas.editor, 'e');
+        editor_insert_char(&canvas.editor, 'w');
+
+        /* Confirm */
+        editor_confirm(&canvas);
+
+        /* Title should be changed */
+        Box *box = canvas_get_box(&canvas, id);
+        ASSERT(strcmp(box->title, "New") == 0, "Title changed to 'New'");
+
+        /* Undo should restore original */
+        ASSERT(canvas_can_undo(&canvas), "Can undo");
+        canvas_undo(&canvas);
+        ASSERT(strcmp(box->title, "Original") == 0, "Title restored by undo");
+
+        /* Redo should re-apply */
+        canvas_redo(&canvas);
+        ASSERT(strcmp(box->title, "New") == 0, "Title changed again by redo");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("NULL safety") {
+        /* These should not crash */
+        editor_init(NULL);
+        editor_cleanup(NULL);
+        editor_cancel(NULL);
+
+        ASSERT(!editor_is_active(NULL), "NULL canvas is not active");
+        ASSERT(editor_get_buffer(NULL) != NULL, "NULL editor returns empty string");
+        ASSERT(strlen(editor_get_buffer(NULL)) == 0, "Empty string from NULL");
+        ASSERT_EQ(editor_get_cursor_pos(NULL), 0, "Zero cursor from NULL");
+    }
+
+    TEST_END();
+}

--- a/tests/test_undo.c
+++ b/tests/test_undo.c
@@ -1,0 +1,394 @@
+#define _POSIX_C_SOURCE 200809L
+#include <math.h>
+#include <string.h>
+#include "test.h"
+#include "../include/canvas.h"
+#include "../include/undo.h"
+#include "../include/types.h"
+
+int main(void) {
+    TEST_START();
+
+    TEST("Undo stack initialization in canvas") {
+        Canvas canvas;
+        int result = canvas_init(&canvas, 200.0, 100.0);
+
+        ASSERT_EQ(result, 0, "canvas_init returns 0");
+        ASSERT(!canvas_can_undo(&canvas), "Cannot undo on fresh canvas");
+        ASSERT(!canvas_can_redo(&canvas), "Cannot redo on fresh canvas");
+        ASSERT_EQ(canvas.undo_stack.size, 0, "Undo stack is empty");
+        ASSERT_EQ(canvas.undo_stack.max_size, UNDO_STACK_MAX_SIZE, "Max size is default");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Undo/Redo box creation") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id = canvas_add_box(&canvas, 10.0, 20.0, 30, 5, "Test Box");
+        ASSERT(id > 0, "Box created successfully");
+        ASSERT_EQ(canvas.box_count, 1, "Box count is 1");
+
+        /* Record the creation for undo */
+        undo_record_box_create(&canvas, id);
+        ASSERT(canvas_can_undo(&canvas), "Can undo after recording");
+
+        /* Undo the creation */
+        bool undone = canvas_undo(&canvas);
+        ASSERT(undone, "Undo succeeded");
+        ASSERT_EQ(canvas.box_count, 0, "Box removed after undo");
+        ASSERT(!canvas_can_undo(&canvas), "Cannot undo again");
+        ASSERT(canvas_can_redo(&canvas), "Can redo after undo");
+
+        /* Redo the creation */
+        bool redone = canvas_redo(&canvas);
+        ASSERT(redone, "Redo succeeded");
+        ASSERT_EQ(canvas.box_count, 1, "Box restored after redo");
+        ASSERT(canvas_can_undo(&canvas), "Can undo after redo");
+        ASSERT(!canvas_can_redo(&canvas), "Cannot redo again");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Undo/Redo box deletion") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id = canvas_add_box(&canvas, 10.0, 20.0, 30, 5, "Test Box");
+        ASSERT_EQ(canvas.box_count, 1, "Box created");
+
+        /* Record the deletion before actually deleting */
+        undo_record_box_delete(&canvas, id);
+
+        /* Delete the box */
+        canvas_remove_box(&canvas, id);
+        ASSERT_EQ(canvas.box_count, 0, "Box deleted");
+
+        /* Undo the deletion */
+        bool undone = canvas_undo(&canvas);
+        ASSERT(undone, "Undo succeeded");
+        ASSERT_EQ(canvas.box_count, 1, "Box restored after undo");
+
+        /* Verify box properties were restored */
+        Box *box = canvas_get_box(&canvas, canvas.boxes[0].id);
+        ASSERT_NOT_NULL(box, "Can get restored box");
+        ASSERT(fabs(box->x - 10.0) < 0.001, "X position restored");
+        ASSERT(fabs(box->y - 20.0) < 0.001, "Y position restored");
+        ASSERT_EQ(box->width, 30, "Width restored");
+        ASSERT_EQ(box->height, 5, "Height restored");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Undo/Redo box move") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id = canvas_add_box(&canvas, 10.0, 20.0, 30, 5, "Test Box");
+        Box *box = canvas_get_box(&canvas, id);
+
+        /* Record and perform the move */
+        undo_record_box_move(&canvas, id, 10.0, 20.0, 50.0, 60.0);
+        box->x = 50.0;
+        box->y = 60.0;
+
+        ASSERT(fabs(box->x - 50.0) < 0.001, "Box moved to new X");
+        ASSERT(fabs(box->y - 60.0) < 0.001, "Box moved to new Y");
+
+        /* Undo the move */
+        canvas_undo(&canvas);
+        ASSERT(fabs(box->x - 10.0) < 0.001, "Box X restored");
+        ASSERT(fabs(box->y - 20.0) < 0.001, "Box Y restored");
+
+        /* Redo the move */
+        canvas_redo(&canvas);
+        ASSERT(fabs(box->x - 50.0) < 0.001, "Box X re-applied");
+        ASSERT(fabs(box->y - 60.0) < 0.001, "Box Y re-applied");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Undo/Redo box color") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id = canvas_add_box(&canvas, 10.0, 20.0, 30, 5, "Test Box");
+        Box *box = canvas_get_box(&canvas, id);
+
+        ASSERT_EQ(box->color, 0, "Initial color is 0");
+
+        /* Record and perform the color change */
+        undo_record_box_color(&canvas, id, 0, 3);
+        box->color = 3;
+
+        ASSERT_EQ(box->color, 3, "Color changed to 3");
+
+        /* Undo the color change */
+        canvas_undo(&canvas);
+        ASSERT_EQ(box->color, 0, "Color restored to 0");
+
+        /* Redo the color change */
+        canvas_redo(&canvas);
+        ASSERT_EQ(box->color, 3, "Color re-applied to 3");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Undo/Redo box title") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id = canvas_add_box(&canvas, 10.0, 20.0, 30, 5, "Original");
+        Box *box = canvas_get_box(&canvas, id);
+
+        ASSERT(strcmp(box->title, "Original") == 0, "Initial title correct");
+
+        /* Record and perform the title change */
+        undo_record_box_title(&canvas, id, "Original", "New Title");
+        free(box->title);
+        box->title = strdup("New Title");
+
+        ASSERT(strcmp(box->title, "New Title") == 0, "Title changed");
+
+        /* Undo the title change */
+        canvas_undo(&canvas);
+        ASSERT(strcmp(box->title, "Original") == 0, "Title restored");
+
+        /* Redo the title change */
+        canvas_redo(&canvas);
+        ASSERT(strcmp(box->title, "New Title") == 0, "Title re-applied");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Undo stack limit") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        /* Set a small max size for testing */
+        canvas.undo_stack.max_size = 5;
+
+        /* Create 10 boxes (10 operations) */
+        for (int i = 0; i < 10; i++) {
+            int id = canvas_add_box(&canvas, i * 10.0, 0.0, 20, 5, "Box");
+            undo_record_box_create(&canvas, id);
+        }
+
+        ASSERT_EQ(canvas.box_count, 10, "Created 10 boxes");
+        ASSERT_EQ(canvas.undo_stack.size, 5, "Stack limited to 5");
+
+        /* Can only undo 5 times */
+        int undo_count = 0;
+        while (canvas_undo(&canvas)) {
+            undo_count++;
+        }
+        ASSERT_EQ(undo_count, 5, "Could only undo 5 times");
+        ASSERT_EQ(canvas.box_count, 5, "5 boxes remain after undo");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("New operation clears redo stack") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        /* Create and record a box */
+        int id1 = canvas_add_box(&canvas, 10.0, 20.0, 30, 5, "Box 1");
+        undo_record_box_create(&canvas, id1);
+
+        /* Undo it */
+        canvas_undo(&canvas);
+        ASSERT(canvas_can_redo(&canvas), "Can redo after undo");
+
+        /* Create another box (new operation) */
+        int id2 = canvas_add_box(&canvas, 50.0, 60.0, 25, 5, "Box 2");
+        undo_record_box_create(&canvas, id2);
+
+        /* Redo should now be unavailable */
+        ASSERT(!canvas_can_redo(&canvas), "Redo cleared after new operation");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Multiple undos and redos") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        /* Create 3 boxes */
+        int id1 = canvas_add_box(&canvas, 10.0, 10.0, 20, 5, "Box 1");
+        undo_record_box_create(&canvas, id1);
+
+        int id2 = canvas_add_box(&canvas, 30.0, 30.0, 20, 5, "Box 2");
+        undo_record_box_create(&canvas, id2);
+
+        int id3 = canvas_add_box(&canvas, 50.0, 50.0, 20, 5, "Box 3");
+        undo_record_box_create(&canvas, id3);
+
+        ASSERT_EQ(canvas.box_count, 3, "Created 3 boxes");
+
+        /* Undo all 3 */
+        canvas_undo(&canvas);
+        ASSERT_EQ(canvas.box_count, 2, "2 boxes after first undo");
+
+        canvas_undo(&canvas);
+        ASSERT_EQ(canvas.box_count, 1, "1 box after second undo");
+
+        canvas_undo(&canvas);
+        ASSERT_EQ(canvas.box_count, 0, "0 boxes after third undo");
+
+        /* Redo all 3 */
+        canvas_redo(&canvas);
+        ASSERT_EQ(canvas.box_count, 1, "1 box after first redo");
+
+        canvas_redo(&canvas);
+        ASSERT_EQ(canvas.box_count, 2, "2 boxes after second redo");
+
+        canvas_redo(&canvas);
+        ASSERT_EQ(canvas.box_count, 3, "3 boxes after third redo");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Undo/Redo connection creation") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id1 = canvas_add_box(&canvas, 10.0, 10.0, 20, 5, "Box 1");
+        int id2 = canvas_add_box(&canvas, 50.0, 50.0, 20, 5, "Box 2");
+
+        int conn_id = canvas_add_connection(&canvas, id1, id2);
+        ASSERT(conn_id > 0, "Connection created");
+        ASSERT_EQ(canvas.conn_count, 1, "Connection count is 1");
+
+        /* Record for undo */
+        undo_record_connection_create(&canvas, conn_id);
+
+        /* Undo the connection */
+        canvas_undo(&canvas);
+        ASSERT_EQ(canvas.conn_count, 0, "Connection removed after undo");
+
+        /* Redo the connection */
+        canvas_redo(&canvas);
+        ASSERT_EQ(canvas.conn_count, 1, "Connection restored after redo");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Undo/Redo connection deletion") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id1 = canvas_add_box(&canvas, 10.0, 10.0, 20, 5, "Box 1");
+        int id2 = canvas_add_box(&canvas, 50.0, 50.0, 20, 5, "Box 2");
+
+        int conn_id = canvas_add_connection(&canvas, id1, id2);
+        ASSERT_EQ(canvas.conn_count, 1, "Connection created");
+
+        /* Record before deletion */
+        undo_record_connection_delete(&canvas, conn_id);
+
+        /* Delete the connection */
+        canvas_remove_connection(&canvas, conn_id);
+        ASSERT_EQ(canvas.conn_count, 0, "Connection deleted");
+
+        /* Undo the deletion */
+        canvas_undo(&canvas);
+        ASSERT_EQ(canvas.conn_count, 1, "Connection restored after undo");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("NULL canvas safety") {
+        /* These should not crash */
+        bool result = canvas_undo(NULL);
+        ASSERT(!result, "Undo on NULL returns false");
+
+        result = canvas_redo(NULL);
+        ASSERT(!result, "Redo on NULL returns false");
+
+        ASSERT(!canvas_can_undo(NULL), "Can undo on NULL is false");
+        ASSERT(!canvas_can_redo(NULL), "Can redo on NULL is false");
+
+        const char *desc = canvas_get_undo_description(NULL);
+        ASSERT_NULL(desc, "Undo description on NULL is NULL");
+
+        desc = canvas_get_redo_description(NULL);
+        ASSERT_NULL(desc, "Redo description on NULL is NULL");
+    }
+
+    TEST("Operation descriptions") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id = canvas_add_box(&canvas, 10.0, 20.0, 30, 5, "Test");
+        undo_record_box_create(&canvas, id);
+
+        const char *desc = canvas_get_undo_description(&canvas);
+        ASSERT_NOT_NULL(desc, "Has undo description");
+        ASSERT(strcmp(desc, "create box") == 0, "Description is 'create box'");
+
+        canvas_undo(&canvas);
+
+        desc = canvas_get_redo_description(&canvas);
+        ASSERT_NOT_NULL(desc, "Has redo description");
+        ASSERT(strcmp(desc, "create box") == 0, "Redo description is 'create box'");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST("Undo stack cleanup frees memory") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        /* Create several operations with string allocations */
+        for (int i = 0; i < 10; i++) {
+            int id = canvas_add_box(&canvas, i * 10.0, 0.0, 20, 5, "Box");
+            undo_record_box_create(&canvas, id);
+        }
+
+        /* Undo half of them (creates redo chain) */
+        for (int i = 0; i < 5; i++) {
+            canvas_undo(&canvas);
+        }
+
+        /* Cleanup should free both chains without leaks */
+        canvas_cleanup(&canvas);
+
+        /* If we get here without valgrind errors, test passed */
+        ASSERT(true, "Cleanup completed without crash");
+    }
+
+    TEST("Undo/Redo box resize") {
+        Canvas canvas;
+        canvas_init(&canvas, 200.0, 100.0);
+
+        int id = canvas_add_box(&canvas, 10.0, 20.0, 30, 10, "Test Box");
+        Box *box = canvas_get_box(&canvas, id);
+
+        ASSERT_EQ(box->width, 30, "Initial width");
+        ASSERT_EQ(box->height, 10, "Initial height");
+
+        /* Record and perform the resize */
+        undo_record_box_resize(&canvas, id, 30, 10, 50, 20);
+        box->width = 50;
+        box->height = 20;
+
+        ASSERT_EQ(box->width, 50, "Width changed");
+        ASSERT_EQ(box->height, 20, "Height changed");
+
+        /* Undo the resize */
+        canvas_undo(&canvas);
+        ASSERT_EQ(box->width, 30, "Width restored");
+        ASSERT_EQ(box->height, 10, "Height restored");
+
+        /* Redo the resize */
+        canvas_redo(&canvas);
+        ASSERT_EQ(box->width, 50, "Width re-applied");
+        ASSERT_EQ(box->height, 20, "Height re-applied");
+
+        canvas_cleanup(&canvas);
+    }
+
+    TEST_END();
+}


### PR DESCRIPTION
## Summary

Implements two core UX features that enable safer experimentation and direct content editing:

- **Undo/Redo (#81)**: Full operation history with `u`/`Ctrl+Z` to undo and `Ctrl+R` to redo. Supports box create, delete, move, resize, color, and title changes.
- **Text Editing (#79 Phase 1)**: Press `Enter` on a selected box to edit its title inline. Cursor navigation, insert/delete, `Escape` to cancel, `Enter` to confirm.

Fixes #79
Fixes #81

## Changes

- Add `UndoStack`, `Operation`, `BoxSnapshot`, `ConnectionSnapshot` types to `types.h`
- Add `TextEditor` and `EditTarget` types for edit mode state
- Implement `src/undo.c` (~570 lines) with full undo/redo stack management
- Implement `src/editor.c` (~210 lines) for inline title editing
- Add `render_edit_mode()` to show cursor position during editing
- Integrate keybinds in `input.c` and `input_unified.c`
- Add 119 new test assertions (78 for undo, 41 for editor)

## Testing

- [x] All tests pass (`make test`)
- [x] No compiler warnings (`-Wall -Wextra -Werror`)

## Type

- [x] New feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)